### PR TITLE
security: サプライチェーンハードニング対応（提案・自動生成）

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,8 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
           go-version-file: ./go.mod
       - run: go mod download

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.head_commit.message, '[skip ci]') == false
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
           go-version-file: ./go.mod
       - name: Generate files by openapi-generator


### PR DESCRIPTION
> [!IMPORTANT]
> **これは自動生成された「対応提案」PR です。**
> CI／サプライチェーンのハードニングを進めやすくするために機械的に変更を加えています。
> **変更内容が正しいか・CI が通るかは必ずメンテナご自身でご確認ください。** 誤検出や、このリポジトリの文脈では不要な変更が含まれている可能性があります。不要なものは部分的に revert／close いただいて構いません。

traPtitech org 全体のセキュリティ監査に基づく提案です。

## 適用した変更

### ✅ GitHub Actions を commit SHA で固定（4 箇所）
タグ／ブランチ参照は可変で付け替えられ得るため、不変な commit SHA に固定しました（[pinact](https://github.com/suzuki-shunsuke/pinact) を使用）。`# vX` コメントを残しているので **Dependabot / Renovate は引き続き自動更新できます**。

## 確認のお願い
- [x] CI が通ることを確認した

## 参考
- SHA pinning: [pinact](https://github.com/suzuki-shunsuke/pinact) ／ Dependabot（`github-actions`）・Renovate（`helpers:pinGitHubActionDigests`）でも自動更新できます

---
🤖 この PR は traPtitech org セキュリティ監査の一環として自動生成されました。